### PR TITLE
deleted zero-sized collision boxes, removed visual names

### DIFF
--- a/description/urdf/pioneer-lx.urdf
+++ b/description/urdf/pioneer-lx.urdf
@@ -11,7 +11,7 @@
       <!-- 60 kg minus each wheel -->
       <inertia ixx="1" ixy="0" ixz="0" iyy="1" iyz="0" izz="1"/>
     </inertial>
-    <visual name="base_link_visual">
+    <visual>
       <geometry name="base_link_visual_geom">
         <mesh filename="package://amr_robots_description/meshes/pioneer-lx/pioneer-lx_visual.stl" scale="0.001 0.001 0.001"/>
       </geometry>
@@ -33,7 +33,7 @@
     </inertial>
     <!--
 TODO separate out pioner lx wheels in visual model 
-    <visual name="r_wheel_dumb_visual">
+    <visual>
       <geometry name="r_wheel_dumb_visual_geom">
         <cylinder radius="0.100" length="0.05" />
       </geometry>
@@ -55,7 +55,7 @@ TODO separate out pioner lx wheels in visual model
       <inertia ixx="0.02" ixy="0" ixz="0" iyy="0.02" iyz="0" izz="0.01"/>
     </inertial>
     <!--
-    <visual name="l_wheel_dumb_visual">
+    <visual>
       <geometry name="l_wheel_dumb_visual_geom">
         <cylinder radius="0.100" length="0.05" />
       </geometry>
@@ -82,7 +82,7 @@ TODO separate out pioner lx wheels in visual model
   </joint>
   <!-- pioneer lx deck -->
   <link name="deck">
-    <visual name="deck_visual">
+    <visual>
       <geometry name="deck_visual_geom">
         <box size="0.407 0.437 0.076"/>
       </geometry>

--- a/description/urdf/pioneer-lx.urdf.xacro
+++ b/description/urdf/pioneer-lx.urdf.xacro
@@ -11,7 +11,7 @@
       <inertia ixx="1" ixy="0" ixz="0" iyy="1" iyz="0" izz="1" />
     </inertial>
 
-    <visual name="base_link_visual">
+    <visual>
       <geometry name="base_link_visual_geom">
         <mesh filename="package://amr_robots_description/meshes/pioneer-lx/pioneer-lx_visual.stl" scale="0.001 0.001 0.001" />
       </geometry>
@@ -39,7 +39,7 @@
 
 <!--
 TODO separate out pioner lx wheels in visual model 
-    <visual name="r_wheel_dumb_visual">
+    <visual>
       <geometry name="r_wheel_dumb_visual_geom">
         <cylinder radius="0.100" length="0.05" />
       </geometry>
@@ -66,7 +66,7 @@ TODO separate out pioner lx wheels in visual model
     </inertial>
 
 <!--
-    <visual name="l_wheel_dumb_visual">
+    <visual>
       <geometry name="l_wheel_dumb_visual_geom">
         <cylinder radius="0.100" length="0.05" />
       </geometry>
@@ -100,7 +100,7 @@ TODO separate out pioner lx wheels in visual model
 
   <!-- pioneer lx deck -->
   <link name="deck">
-    <visual name="deck_visual">
+    <visual>
       <geometry name="deck_visual_geom">
         <box size="0.407 0.437 0.076" />
       </geometry>

--- a/description/urdf/pioneer3at.urdf
+++ b/description/urdf/pioneer3at.urdf
@@ -19,7 +19,7 @@
       <origin xyz="0 -0.1 0.177"/>
       <inertia ixx="0.3338" ixy="0.0" ixz="0.0" iyy="0.4783" iyz="0.0" izz="0.3338"/>
     </inertial>
-    <visual name="base_visual">
+    <visual>
       <origin rpy="0 0 0" xyz="0 0 0.177"/>
       <geometry name="pioneer_geom">
         <mesh filename="package://amr_robots_description/meshes/p3at_meshes/chassis.stl"/>
@@ -45,7 +45,7 @@
       <origin xyz="-0.025 0 -0.223"/>
       <inertia ixx="1.0" ixy="0.0" ixz="0.0" iyy="1.0" iyz="0.0" izz="1.0"/>
     </inertial>
-    <visual name="base_visual">
+    <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry name="pioneer_geom">
         <mesh filename="package://amr_robots_description/meshes/p3at_meshes/top.stl"/>
@@ -54,12 +54,6 @@
         <color rgba="0.038 0.038 0.038 1.0"/>
       </material>
     </visual>
-    <collision>
-      <origin rpy="0 0 0" xyz="0 0 0"/>
-      <geometry>
-        <box size="0 0 0"/>
-      </geometry>
-    </collision>
   </link>
   <gazebo reference="top_plate">
     <material>Gazebo/Black</material>
@@ -76,7 +70,7 @@
       <origin xyz="0 0 0"/>
       <inertia ixx="1.0" ixy="0.0" ixz="0.0" iyy="1.0" iyz="0.0" izz="1.0"/>
     </inertial>
-    <visual name="base_visual">
+    <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry name="pioneer_geom">
         <mesh filename="package://amr_robots_description/meshes/p3at_meshes/front_sonar.stl"/>
@@ -85,12 +79,6 @@
         <color rgba="0.715 0.583 0.210 1.0"/>
       </material>
     </visual>
-    <collision>
-      <origin rpy="0 0 0" xyz="0 0 0"/>
-      <geometry>
-        <box size="0 0 0"/>
-      </geometry>
-    </collision>
   </link>
   <gazebo reference="front_sonar">
     <material value="Gazebo/Yellow"/>
@@ -106,7 +94,7 @@
       <origin xyz="0 0 0"/>
       <inertia ixx="1.0" ixy="0.0" ixz="0.0" iyy="1.0" iyz="0.0" izz="1.0"/>
     </inertial>
-    <visual name="base_visual">
+    <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry name="pioneer_geom">
         <mesh filename="package://amr_robots_description/meshes/p3at_meshes/back_sonar.stl"/>
@@ -115,12 +103,6 @@
         <color rgba="0.715 0.583 0.210 1.0"/>
       </material>
     </visual>
-    <collision>
-      <origin rpy="0 0 0" xyz="0 0 0"/>
-      <geometry>
-        <box size="0 0 0"/>
-      </geometry>
-    </collision>
   </link>
   <gazebo reference="back_sonar">
     <material value="Gazebo/Yellow"/>
@@ -137,7 +119,7 @@
       <origin xyz="0 0 0"/>
       <inertia ixx="1.0" ixy="0.0" ixz="0.0" iyy="1.0" iyz="0.0" izz="1.0"/>
     </inertial>
-    <visual name="base_visual">
+    <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry name="pioneer_geom">
         <mesh filename="package://amr_robots_description/meshes/p3at_meshes/axle.stl"/>
@@ -146,12 +128,6 @@
         <color rgba="0.5 0.5 0.5 1"/>
       </material>
     </visual>
-    <collision>
-      <origin rpy="0 0 0" xyz="0 0 0"/>
-      <geometry>
-        <box size="0 0 0"/>
-      </geometry>
-    </collision>
   </link>
   <gazebo reference="p3at_front_left_axle">
     <material value="Gazebo/Grey"/>
@@ -167,7 +143,7 @@
       <origin xyz="0 0 0"/>
       <inertia ixx="1.0" ixy="0.0" ixz="0.0" iyy="1.0" iyz="0.0" izz="1.0"/>
     </inertial>
-    <visual name="base_visual">
+    <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry name="pioneer_geom">
         <mesh filename="package://amr_robots_description/meshes/p3at_meshes/left_hubcap.stl"/>
@@ -176,12 +152,6 @@
         <color rgba="1.0 0.811 0.151 1.0"/>
       </material>
     </visual>
-    <collision>
-      <origin rpy="0 0 0" xyz="0 0 0"/>
-      <geometry>
-        <box size="0 0 0"/>
-      </geometry>
-    </collision>
   </link>
   <gazebo reference="p3at_front_left_hub">
     <material value="Gazebo/Yellow"/>
@@ -198,7 +168,7 @@
       <origin xyz="0 0 0"/>
       <inertia ixx="0.012411765597" ixy="0" ixz="0" iyy="0.015218160428" iyz="0" izz="0.011763977943"/>
     </inertial>
-    <visual name="base_visual">
+    <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry name="pioneer_geom">
         <mesh filename="package://amr_robots_description/meshes/p3at_meshes/wheel.stl"/>
@@ -234,7 +204,7 @@
       <origin xyz="0 0 0"/>
       <inertia ixx="1.0" ixy="0.0" ixz="0.0" iyy="1.0" iyz="0.0" izz="1.0"/>
     </inertial>
-    <visual name="base_visual">
+    <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry name="pioneer_geom">
         <mesh filename="package://amr_robots_description/meshes/p3at_meshes/axle.stl"/>
@@ -264,7 +234,7 @@
       <origin xyz="0 0 0"/>
       <inertia ixx="1.0" ixy="0.0" ixz="0.0" iyy="1.0" iyz="0.0" izz="1.0"/>
     </inertial>
-    <visual name="base_visual">
+    <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry name="pioneer_geom">
         <mesh filename="package://amr_robots_description/meshes/p3at_meshes/left_hubcap.stl"/>
@@ -292,7 +262,7 @@
       <origin xyz="0 0 0"/>
       <inertia ixx="0.012411765597" ixy="0" ixz="0" iyy="0.015218160428" iyz="0" izz="0.011763977943"/>
     </inertial>
-    <visual name="base_visual">
+    <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry name="pioneer_geom">
         <mesh filename="package://amr_robots_description/meshes/p3at_meshes/wheel.stl"/>
@@ -361,7 +331,7 @@
       <origin xyz="0 0 0"/>
       <inertia ixx="1.0" ixy="0.0" ixz="0.0" iyy="1.0" iyz="0.0" izz="1.0"/>
     </inertial>
-    <visual name="base_visual">
+    <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry name="pioneer_geom">
         <mesh filename="package://amr_robots_description/meshes/p3at_meshes/axle.stl"/>
@@ -370,12 +340,6 @@
         <color rgba="0.5 0.5 0.5 1"/>
       </material>
     </visual>
-    <collision>
-      <origin rpy="0 0 0" xyz="0 0 0"/>
-      <geometry>
-        <box size="0 0 0"/>
-      </geometry>
-    </collision>
   </link>
   <gazebo reference="p3at_front_right_axle">
     <material value="Gazebo/Grey"/>
@@ -391,7 +355,7 @@
       <origin xyz="0 0 0"/>
       <inertia ixx="1.0" ixy="0.0" ixz="0.0" iyy="1.0" iyz="0.0" izz="1.0"/>
     </inertial>
-    <visual name="base_visual">
+    <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry name="pioneer_geom">
         <mesh filename="package://amr_robots_description/meshes/p3at_meshes/right_hubcap.stl"/>
@@ -400,12 +364,6 @@
         <color rgba="1.0 0.811 0.151 1.0"/>
       </material>
     </visual>
-    <collision>
-      <origin rpy="0 0 0" xyz="0 0 0"/>
-      <geometry>
-        <box size="0 0 0"/>
-      </geometry>
-    </collision>
   </link>
   <gazebo reference="p3at_front_right_hub">
     <material value="Gazebo/Yellow"/>
@@ -422,7 +380,7 @@
       <origin xyz="0 0 0"/>
       <inertia ixx="0.012411765597" ixy="0" ixz="0" iyy="0.015218160428" iyz="0" izz="0.011763977943"/>
     </inertial>
-    <visual name="base_visual">
+    <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry name="pioneer_geom">
         <mesh filename="package://amr_robots_description/meshes/p3at_meshes/wheel.stl"/>
@@ -458,7 +416,7 @@
       <origin xyz="0 0 0"/>
       <inertia ixx="1.0" ixy="0.0" ixz="0.0" iyy="1.0" iyz="0.0" izz="1.0"/>
     </inertial>
-    <visual name="base_visual">
+    <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry name="pioneer_geom">
         <mesh filename="package://amr_robots_description/meshes/p3at_meshes/axle.stl"/>
@@ -488,7 +446,7 @@
       <origin xyz="0 0 0"/>
       <inertia ixx="1.0" ixy="0.0" ixz="0.0" iyy="1.0" iyz="0.0" izz="1.0"/>
     </inertial>
-    <visual name="base_visual">
+    <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry name="pioneer_geom">
         <mesh filename="package://amr_robots_description/meshes/p3at_meshes/right_hubcap.stl"/>
@@ -516,7 +474,7 @@
       <origin xyz="0 0 0"/>
       <inertia ixx="0.012411765597" ixy="0" ixz="0" iyy="0.015218160428" iyz="0" izz="0.011763977943"/>
     </inertial>
-    <visual name="base_visual">
+    <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry name="pioneer_geom">
         <mesh filename="package://amr_robots_description/meshes/p3at_meshes/wheel.stl"/>

--- a/description/urdf/pioneer3at.urdf.xacro
+++ b/description/urdf/pioneer3at.urdf.xacro
@@ -24,7 +24,7 @@ name="pioneer3at">
 				              iyy="0.4783"  iyz="0.0"
 				                            izz="0.3338"/>
 		</inertial>
-		<visual name="base_visual">
+		<visual>
 			<origin xyz="0 0 0.177" rpy="0 0 0"/>
 			<geometry name="pioneer_geom">
 				<mesh filename="package://amr_robots_description/meshes/p3at_meshes/chassis.stl"/>
@@ -53,7 +53,7 @@ name="pioneer3at">
 				 iyy="1.0" iyz="0.0"
  				izz="1.0"/>
 		</inertial>
-		<visual name="base_visual">
+		<visual>
 			<origin xyz="0 0 0" rpy="0 0 0"/>
 			<geometry name="pioneer_geom">
 				<mesh filename="package://amr_robots_description/meshes/p3at_meshes/top.stl"/>
@@ -62,12 +62,7 @@ name="pioneer3at">
 					<color rgba="0.038 0.038 0.038 1.0"/>
 			</material>
 		</visual>
-		<collision>
-			<origin xyz="0 0 0" rpy="0 0 0"/>
-			<geometry>
-				<box size="0 0 0"/>
-			</geometry>
-		</collision>
+
 	</link>
 	<gazebo reference="top_plate">
     <material>Gazebo/Black</material>
@@ -86,7 +81,7 @@ name="pioneer3at">
 			<inertia ixx="1.0" ixy="0.0" ixz="0.0"
 				 iyy="1.0" iyz="0.0" izz="1.0"/>
 		</inertial>
-		<visual name="base_visual">
+		<visual>
 			<origin xyz="0 0 0" rpy="0 0 0"/>
 			<geometry name="pioneer_geom">
 				<mesh filename="package://amr_robots_description/meshes/p3at_meshes/front_sonar.stl"/>
@@ -95,12 +90,6 @@ name="pioneer3at">
 				<color rgba="0.715 0.583 0.210 1.0"/>
 			</material>
 		</visual>
-		<collision>
-			<origin xyz="0 0 0" rpy="0 0 0"/>
-			<geometry>
-				<box size="0 0 0"/>
-			</geometry>
-		</collision>
 	</link>
 	<gazebo reference="front_sonar">
 		<material value="Gazebo/Yellow"/>
@@ -119,7 +108,7 @@ name="pioneer3at">
 			<inertia ixx="1.0" ixy="0.0" ixz="0.0"
 				 iyy="1.0" iyz="0.0" izz="1.0"/>
 		</inertial>
-		<visual name="base_visual">
+		<visual>
 			<origin xyz="0 0 0" rpy="0 0 0"/>
 			<geometry name="pioneer_geom">
 				<mesh filename="package://amr_robots_description/meshes/p3at_meshes/back_sonar.stl"/>
@@ -128,12 +117,6 @@ name="pioneer3at">
 				<color rgba="0.715 0.583 0.210 1.0"/>
 			</material>
 		</visual>
-		<collision>
-			<origin xyz="0 0 0" rpy="0 0 0"/>
-			<geometry>
-				<box size="0 0 0"/>
-			</geometry>
-		</collision>
 	</link>
 	<gazebo reference="back_sonar">
 		<material value="Gazebo/Yellow"/>
@@ -155,7 +138,7 @@ name="pioneer3at">
 			<inertia ixx="1.0" ixy="0.0" ixz="0.0"
 				 iyy="1.0" iyz="0.0" izz="1.0"/>
   	 	</inertial>
-	<visual name="base_visual">
+	<visual>
 		<origin xyz="0 0 0" rpy="0 0 0"/>
 		<geometry name="pioneer_geom">
 			<mesh filename="package://amr_robots_description/meshes/p3at_meshes/axle.stl"/>
@@ -164,12 +147,6 @@ name="pioneer3at">
 			<color rgba="0.5 0.5 0.5 1"/>
 		</material>
 	</visual>
-	<collision>
-		<origin xyz="0 0 0" rpy="0 0 0"/>
-		<geometry>
-			<box size="0 0 0"/>
-		</geometry>
-	</collision>
 	</link>
 	<gazebo reference="p3at_front_${side}_axle">
 		<material value="Gazebo/Grey"/>
@@ -188,7 +165,7 @@ name="pioneer3at">
 			<inertia ixx="1.0" ixy="0.0" ixz="0.0"
 				 iyy="1.0" iyz="0.0" izz="1.0"/>
   	 	</inertial>
-	<visual name="base_visual">
+	<visual>
 		<origin xyz="0 0 0" rpy="0 0 0"/>
 		<geometry name="pioneer_geom">
 			<mesh filename="package://amr_robots_description/meshes/p3at_meshes/${side}_hubcap.stl"/>
@@ -197,12 +174,6 @@ name="pioneer3at">
 			<color rgba="1.0 0.811 0.151 1.0"/>
 		</material>
 	</visual>
-	<collision>
-		<origin xyz="0 0 0" rpy="0 0 0"/>
-		<geometry>
-			<box size="0 0 0"/>
-		</geometry>
-	</collision>
 	</link>
 	<gazebo reference="p3at_front_${side}_hub">
 		<material value="Gazebo/Yellow"/>
@@ -221,7 +192,7 @@ name="pioneer3at">
 			<inertia ixx="0.012411765597" ixy="0" ixz="0"
          iyy="0.015218160428" iyz="0" izz="0.011763977943"/>
       </inertial>
-	<visual name="base_visual">
+	<visual>
 		<origin xyz="0 0 0" rpy="0 0 0"/>
 		<geometry name="pioneer_geom">
 			<mesh filename="package://amr_robots_description/meshes/p3at_meshes/wheel.stl"/>
@@ -260,7 +231,7 @@ name="pioneer3at">
 			<inertia ixx="1.0" ixy="0.0" ixz="0.0"
 				 iyy="1.0" iyz="0.0" izz="1.0"/>
   	 	</inertial>
-	<visual name="base_visual">
+	<visual>
 		<origin xyz="0 0 0" rpy="0 0 0"/>
 		<geometry name="pioneer_geom">
 			<mesh filename="package://amr_robots_description/meshes/p3at_meshes/axle.stl"/>
@@ -294,7 +265,7 @@ name="pioneer3at">
 			<inertia ixx="1.0" ixy="0.0" ixz="0.0"
 				 iyy="1.0" iyz="0.0" izz="1.0"/>
   	 	</inertial>
-	<visual name="base_visual">
+	<visual>
 		<origin xyz="0 0 0" rpy="0 0 0"/>
 		<geometry name="pioneer_geom">
 			<mesh filename="package://amr_robots_description/meshes/p3at_meshes/${side}_hubcap.stl"/>
@@ -326,7 +297,7 @@ name="pioneer3at">
                                                       iyy="0.015218160428" iyz="0" 
                                                                            izz="0.011763977943"/>
       </inertial>
-	<visual name="base_visual">
+	<visual>
 		<origin xyz="0 0 0" rpy="0 0 0"/>
 		<geometry name="pioneer_geom">
 			<mesh filename="package://amr_robots_description/meshes/p3at_meshes/wheel.stl"/>

--- a/description/urdf/pioneer3at_body.xacro
+++ b/description/urdf/pioneer3at_body.xacro
@@ -15,7 +15,7 @@
 				 iyy="0.4783" iyz="0.0"
 				 izz="0.3338"/>
 		</inertial>
-		<visual name="base_visual">
+		<visual>
 			<origin xyz="0 0 0.177" rpy="0 0 0"/>
 			<geometry name="pioneer_geom">
 				<mesh filename="package://amr_robots_description/meshes/p3at_meshes/chassis.stl"/>
@@ -44,7 +44,7 @@
 				 iyy="1.0" iyz="0.0"
  				izz="1.0"/>
 		</inertial>
-		<visual name="base_visual">
+		<visual>
 			<origin xyz="0 0 0" rpy="0 0 0"/>
 			<geometry name="pioneer_geom">
 				<mesh filename="package://amr_robots_description/meshes/p3at_meshes/top.stl"/>
@@ -53,12 +53,6 @@
 					<color rgba="0.038 0.038 0.038 1.0"/>
 			</material>
 		</visual>
-		<collision>
-			<origin xyz="0 0 0" rpy="0 0 0"/>
-			<geometry>
-				<box size="0 0 0"/>
-			</geometry>
-		</collision>
 	</link>
 	<gazebo reference="top_plate">
 		<material value="Gazebo/Black"/>
@@ -77,7 +71,7 @@
 			<inertia ixx="1.0" ixy="0.0" ixz="0.0"
 				 iyy="1.0" iyz="0.0" izz="1.0"/>
 		</inertial>
-		<visual name="base_visual">
+		<visual>
 			<origin xyz="0 0 0" rpy="0 0 0"/>
 			<geometry name="pioneer_geom">
 				<mesh filename="package://amr_robots_description/meshes/p3at_meshes/front_sonar.stl"/>
@@ -86,12 +80,6 @@
 				<color rgba="0.715 0.583 0.210 1.0"/>
 			</material>
 		</visual>
-		<collision>
-			<origin xyz="0 0 0" rpy="0 0 0"/>
-			<geometry>
-				<box size="0 0 0"/>
-			</geometry>
-		</collision>
 	</link>
 	<gazebo reference="front_sonar">
 		<material value="Gazebo/Yellow"/>
@@ -110,7 +98,7 @@
 			<inertia ixx="1.0" ixy="0.0" ixz="0.0"
 				 iyy="1.0" iyz="0.0" izz="1.0"/>
 		</inertial>
-		<visual name="base_visual">
+		<visual>
 			<origin xyz="0 0 0" rpy="0 0 0"/>
 			<geometry name="pioneer_geom">
 				<mesh filename="package://amr_robots_description/meshes/p3at_meshes/back_sonar.stl"/>
@@ -119,12 +107,6 @@
 				<color rgba="0.715 0.583 0.210 1.0"/>
 			</material>
 		</visual>
-		<collision>
-			<origin xyz="0 0 0" rpy="0 0 0"/>
-			<geometry>
-				<box size="0 0 0"/>
-			</geometry>
-		</collision>
 	</link>
 	<gazebo reference="back_sonar">
 		<material value="Gazebo/Yellow"/>
@@ -145,7 +127,7 @@
 			<inertia ixx="1.0" ixy="0.0" ixz="0.0"
 				 iyy="1.0" iyz="0.0" izz="1.0"/>
   	 	</inertial>
-	<visual name="base_visual">
+	<visual>
 		<origin xyz="0 0 0" rpy="0 0 0"/>
 		<geometry name="pioneer_geom">
 			<mesh filename="package://amr_robots_description/meshes/p3at_meshes/axle.stl"/>
@@ -154,12 +136,6 @@
 			<color rgba="0.5 0.5 0.5 1"/>
 		</material>
 	</visual>
-	<collision>
-		<origin xyz="0 0 0" rpy="0 0 0"/>
-		<geometry>
-			<box size="0 0 0"/>
-		</geometry>
-	</collision>
 	</link>
 	<gazebo reference="p3at_front_${suffix}_axle">
 		<material value="Gazebo/Grey"/>
@@ -178,7 +154,7 @@
 			<inertia ixx="1.0" ixy="0.0" ixz="0.0"
 				 iyy="1.0" iyz="0.0" izz="1.0"/>
   	 	</inertial>
-	<visual name="base_visual">
+	<visual>
 		<origin xyz="0 0 0" rpy="0 0 0"/>
 		<geometry name="pioneer_geom">
 			<mesh filename="package://amr_robots_description/meshes/p3at_meshes/${suffix}_hubcap.stl"/>
@@ -187,12 +163,6 @@
 			<color rgba="1.0 0.811 0.151 1.0"/>
 		</material>
 	</visual>
-	<collision>
-		<origin xyz="0 0 0" rpy="0 0 0"/>
-		<geometry>
-			<box size="0 0 0"/>
-		</geometry>
-	</collision>
 	</link>
 	<gazebo reference="p3at_front_${suffix}_hub">
 		<material value="Gazebo/Yellow"/>
@@ -211,7 +181,7 @@
 			<inertia ixx="0.012411765597" ixy="0" ixz="0"
          iyy="0.015218160428" iyz="0" izz="0.011763977943"/>
       </inertial>
-	<visual name="base_visual">
+	<visual>
 		<origin xyz="0 0 0" rpy="0 0 0"/>
 		<geometry name="pioneer_geom">
 			<mesh filename="package://amr_robots_description/meshes/p3at_meshes/wheel.stl"/>
@@ -250,7 +220,7 @@
 			<inertia ixx="1.0" ixy="0.0" ixz="0.0"
 				 iyy="1.0" iyz="0.0" izz="1.0"/>
   	 	</inertial>
-	<visual name="base_visual">
+	<visual>
 		<origin xyz="0 0 0" rpy="0 0 0"/>
 		<geometry name="pioneer_geom">
 			<mesh filename="package://amr_robots_description/meshes/p3at_meshes/axle.stl"/>
@@ -284,7 +254,7 @@
 			<inertia ixx="1.0" ixy="0.0" ixz="0.0"
 				 iyy="1.0" iyz="0.0" izz="1.0"/>
   	 	</inertial>
-	<visual name="base_visual">
+	<visual>
 		<origin xyz="0 0 0" rpy="0 0 0"/>
 		<geometry name="pioneer_geom">
 			<mesh filename="package://amr_robots_description/meshes/p3at_meshes/${suffix}_hubcap.stl"/>
@@ -315,7 +285,7 @@
 			<inertia ixx="0.012411765597" ixy="0" ixz="0"
          iyy="0.015218160428" iyz="0" izz="0.011763977943"/>
       </inertial>
-	<visual name="base_visual">
+	<visual>
 		<origin xyz="0 0 0" rpy="0 0 0"/>
 		<geometry name="pioneer_geom">
 			<mesh filename="package://amr_robots_description/meshes/p3at_meshes/wheel.stl"/>

--- a/description/urdf/pioneer3dx.urdf
+++ b/description/urdf/pioneer3dx.urdf
@@ -35,7 +35,7 @@
       <origin xyz="0 0 0"/>
       <inertia ixx="1" ixy="0" ixz="0" iyy="1" iyz="0" izz="1"/>
     </inertial>
-    <visual name="pioneer_geom">
+    <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry name="pioneer_geom">
         <mesh filename="package://amr_robots_description/meshes/p3dx_meshes/top.stl"/>
@@ -61,7 +61,7 @@
       <origin xyz="0 0 0"/>
       <inertia ixx="1" ixy="0" ixz="0" iyy="1" iyz="0" izz="1"/>
     </inertial>
-    <visual name="pioneer_geom">
+    <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry name="pioneer_geom">
         <mesh filename="package://amr_robots_description/meshes/p3dx_meshes/front_sonar.stl"/>
@@ -70,12 +70,6 @@
         <color rgba="0.715 0.583 0.210 1.0"/>
       </material>
     </visual>
-    <collision>
-      <origin rpy="0 0 0" xyz="0 0 0"/>
-      <geometry>
-        <box size="0 0 0"/>
-      </geometry>
-    </collision>
   </link>
   <gazebo reference="front_sonar">
     <material value="Gazebo/Yellow"/>
@@ -96,7 +90,7 @@
       <origin xyz="0 0 0"/>
       <inertia ixx="1" ixy="0" ixz="0" iyy="1" iyz="0" izz="1"/>
     </inertial>
-    <visual name="base_visual">
+    <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry name="pioneer_geom">
         <mesh filename="package://amr_robots_description/meshes/p3dx_meshes/back_sonar.stl"/>
@@ -105,12 +99,6 @@
         <color rgba="0.715 0.583 0.210 1.0"/>
       </material>
     </visual>
-    <collision>
-      <origin rpy="0 0 0" xyz="0 0 0"/>
-      <geometry>
-        <box size="0 0 0"/>
-      </geometry>
-    </collision>
   </link>
   <!-- Caster -->
   <joint name="base_caster_swivel_joint" type="continuous">
@@ -127,7 +115,7 @@
       <origin xyz="0 0 0"/>
       <inertia ixx="0.01" ixy="0" ixz="0" iyy="0.01" iyz="0" izz="0.01"/>
     </inertial>
-    <visual name="pioneer_geom">
+    <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry name="pioneer_geom">
         <mesh filename="package://amr_robots_description/meshes/p3dx_meshes/caster_swivel.stl"/>
@@ -136,12 +124,6 @@
         <color rgba="0.5 0.5 0.5 1"/>
       </material>
     </visual>
-    <collision>
-      <origin rpy="0 0 0" xyz="0 0 0"/>
-      <geometry>
-        <box size="0 0 0"/>
-      </geometry>
-    </collision>
   </link>
   <gazebo reference="caster_swivel">
     <material value="Gazebo/Grey"/>
@@ -153,7 +135,7 @@
       <origin xyz="0 0 0"/>
       <inertia ixx="0.012411765597" ixy="-0.000711733678" ixz="0.00050272983" iyy="0.015218160428" iyz="-0.000004273467" izz="0.011763977943"/>
     </inertial>
-    <visual name="pioneer_geom">
+    <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry name="pioneer_geom">
         <mesh filename="package://amr_robots_description/meshes/p3dx_meshes/caster_hubcap.stl"/>
@@ -187,7 +169,7 @@
       <origin xyz="0 0 0"/>
       <inertia ixx="0.012411765597" ixy="-0.000711733678" ixz="0.00050272983" iyy="0.015218160428" iyz="-0.000004273467" izz="0.011763977943"/>
     </inertial>
-    <visual name="pioneer_geom">
+    <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry name="pioneer_geom">
         <mesh filename="package://amr_robots_description/meshes/p3dx_meshes/caster_wheel.stl"/>

--- a/description/urdf/pioneer3dx.urdf.xacro
+++ b/description/urdf/pioneer3dx.urdf.xacro
@@ -45,7 +45,7 @@
 				 iyy="1" iyz="0"
  				izz="1"/>
 		</inertial>
-		<visual name="pioneer_geom">
+		<visual>
 			<origin xyz="0 0 0" rpy="0 0 0"/>
 			<geometry name="pioneer_geom">
 				<mesh filename="package://amr_robots_description/meshes/p3dx_meshes/top.stl"/>
@@ -74,7 +74,7 @@
 			<inertia ixx="1" ixy="0" ixz="0"
 				 iyy="1" iyz="0" izz="1"/>
 		</inertial>
-		<visual name="pioneer_geom">
+		<visual>
 			<origin xyz="0 0 0" rpy="0 0 0"/>
 			<geometry name="pioneer_geom">
 				<mesh filename="package://amr_robots_description/meshes/p3dx_meshes/front_sonar.stl"/>
@@ -83,12 +83,6 @@
 				<color rgba="0.715 0.583 0.210 1.0"/>
 			</material>
 		</visual>
-		<collision>
-			<origin xyz="0 0 0" rpy="0 0 0"/>
-			<geometry>
-				<box size="0 0 0"/>
-			</geometry>
-		</collision>
 	</link>
 
 	<gazebo reference="front_sonar">
@@ -113,7 +107,7 @@
 			<inertia ixx="1" ixy="0" ixz="0"
 				 iyy="1" iyz="0" izz="1"/>
 		</inertial>
-		<visual name="base_visual">
+		<visual>
 			<origin xyz="0 0 0" rpy="0 0 0"/>
 			<geometry name="pioneer_geom">
 				<mesh filename="package://amr_robots_description/meshes/p3dx_meshes/back_sonar.stl"/>
@@ -122,12 +116,6 @@
 				<color rgba="0.715 0.583 0.210 1.0"/>
 			</material>
 		</visual>
-		<collision>
-			<origin xyz="0 0 0" rpy="0 0 0"/>
-			<geometry>
-				<box size="0 0 0"/>
-			</geometry>
-		</collision>
 	</link>
 
 	<!-- Caster -->
@@ -146,7 +134,7 @@
 			<inertia ixx="0.01" ixy="0" ixz="0"
 				 iyy="0.01" iyz="0" izz="0.01"/>
   	 	</inertial>
-	<visual name="pioneer_geom">
+	<visual>
 		<origin xyz="0 0 0" rpy="0 0 0"/>
 		<geometry name="pioneer_geom">
 			<mesh filename="package://amr_robots_description/meshes/p3dx_meshes/caster_swivel.stl"/>
@@ -155,12 +143,6 @@
 			<color rgba="0.5 0.5 0.5 1"/>
 		</material>
 	</visual>
-	<collision>
-		<origin xyz="0 0 0" rpy="0 0 0"/>
-		<geometry>
-			<box size="0 0 0"/>
-		</geometry>
-	</collision>
 	</link>
 	<gazebo reference="caster_swivel">
 		<material value="Gazebo/Grey"/>
@@ -174,7 +156,7 @@
 			<inertia ixx="0.012411765597" ixy="-0.000711733678" ixz="0.00050272983"
 				 iyy="0.015218160428" iyz="-0.000004273467" izz="0.011763977943"/>
   	 	</inertial>
-	<visual name="pioneer_geom">
+	<visual>
 		<origin xyz="0 0 0" rpy="0 0 0"/>
 		<geometry name="pioneer_geom">
 			<mesh filename="package://amr_robots_description/meshes/p3dx_meshes/caster_hubcap.stl"/>
@@ -211,7 +193,7 @@
 			<inertia ixx="0.012411765597" ixy="-0.000711733678" ixz="0.00050272983"
 				 iyy="0.015218160428" iyz="-0.000004273467" izz="0.011763977943"/>
   	 	</inertial>
-	<visual name="pioneer_geom">
+	<visual>
 		<origin xyz="0 0 0" rpy="0 0 0"/>
 		<geometry name="pioneer_geom">
 			<mesh filename="package://amr_robots_description/meshes/p3dx_meshes/caster_wheel.stl"/>

--- a/description/urdf/pioneer3dx_body.xacro
+++ b/description/urdf/pioneer3dx_body.xacro
@@ -20,7 +20,7 @@
 				 izz="0.3338"/>
 		</inertial>
 		<!-- The base visual is fine. Just the inertial is questionable.-->
-		<visual name="pioneer_geom">
+		<visual>
 			<origin xyz="-0.045 0 0.148" rpy="0 0 0"/>
 			<geometry name="pioneer_geom">
 				<mesh filename="package://amr_robots_description/meshes/p3dx_meshes/chassis.stl"/>
@@ -48,7 +48,7 @@
 				 iyy="1" iyz="0"
  				izz="1"/>
 		</inertial>
-		<visual name="pioneer_geom">
+		<visual>
 			<origin xyz="0 0 0" rpy="0 0 0"/>
 			<geometry name="pioneer_geom">
 				<mesh filename="package://amr_robots_description/meshes/p3dx_meshes/top.stl"/>
@@ -84,7 +84,7 @@
 			<inertia ixx="0.01" ixy="0" ixz="0"
 				 iyy="0.01" iyz="0" izz="0.01"/>
   	 	</inertial>
-	<visual name="pioneer_geom">
+	<visual>
 		<origin xyz="0 0 0" rpy="0 0 0"/>
 		<geometry name="pioneer_geom">
 			<mesh filename="package://amr_robots_description/meshes/p3dx_meshes/swivel.stl"/>
@@ -93,12 +93,6 @@
 			<color rgba="0.5 0.5 0.5 1"/>
 		</material>
 	</visual>
-	<collision>
-		<origin xyz="0 0 0" rpy="0 0 0"/>
-		<geometry>
-			<box size="0 0 0"/>
-		</geometry>
-	</collision>
 	</link>
 	<gazebo reference="swivel">
 		<material value="Gazebo/Grey"/>
@@ -112,7 +106,7 @@
 			<inertia ixx="0.012411765597" ixy="-0.000711733678" ixz="0.00050272983"
 				 iyy="0.015218160428" iyz="-0.000004273467" izz="0.011763977943"/>
   	 	</inertial>
-	<visual name="pioneer_geom">
+	<visual>
 		<origin xyz="0 0 0" rpy="0 0 0"/>
 		<geometry name="pioneer_geom">
 			<mesh filename="package://amr_robots_description/meshes/p3dx_meshes/center_hubcap.stl"/>
@@ -149,7 +143,7 @@
 			<inertia ixx="0.012411765597" ixy="-0.000711733678" ixz="0.00050272983"
 				 iyy="0.015218160428" iyz="-0.000004273467" izz="0.011763977943"/>
   	 	</inertial>
-	<visual name="pioneer_geom">
+	<visual>
 		<origin xyz="0 0 0" rpy="0 0 0"/>
 		<geometry name="pioneer_geom">
 			<mesh filename="package://amr_robots_description/meshes/p3dx_meshes/center_wheel.stl"/>
@@ -282,7 +276,7 @@
 			<inertia ixx="1" ixy="0" ixz="0"
 				 iyy="1" iyz="0" izz="1"/>
 		</inertial>
-		<visual name="pioneer_geom">
+		<visual>
 			<origin xyz="0 0 0" rpy="0 0 0"/>
 			<geometry name="pioneer_geom">
 				<mesh filename="package://amr_robots_description/meshes/p3dx_meshes/front_sonar.stl"/>
@@ -291,12 +285,6 @@
 				<color rgba="0.715 0.583 0.210 1.0"/>
 			</material>
 		</visual>
-		<collision>
-			<origin xyz="0 0 0" rpy="0 0 0"/>
-			<geometry>
-				<box size="0 0 0"/>
-			</geometry>
-		</collision>
 	</link>
 
 	<gazebo reference="front_sonar">
@@ -316,7 +304,7 @@
 			<inertia ixx="1" ixy="0" ixz="0"
 				 iyy="1" iyz="0" izz="1"/>
 		</inertial>
-		<visual name="back_sonar_vis">
+		<visual>
 			<origin xyz="0 0 0" rpy="0 0 0"/>
 			<geometry name="pioneer_geom">
 				<mesh filename="package://amr_robots_description/meshes/p3dx_meshes/back_sonar.stl"/>

--- a/description/urdf/pioneer3dx_orig.2.xacro
+++ b/description/urdf/pioneer3dx_orig.2.xacro
@@ -14,7 +14,7 @@
                iyy="1" iyz="0"
                izz="1"/>
   	 	</inertial>
-      <visual name="base_visual">
+      <visual>
         <origin xyz="0 0 0" rpy="0 0 0"/>
 				<geometry name="pioneer_geom">
 					<mesh filename="package://p2os_urdf/meshes/body.stl"/>
@@ -39,7 +39,7 @@
                iyy="1" iyz="0"
                izz="1"/>
   	 	</inertial>
-      <visual name="base_visual">
+      <visual>
         <origin xyz="0 0 0" rpy="0 0 0"/>
 				<geometry name="pioneer_geom">
 					<mesh filename="package://p2os_urdf/meshes/chassis_top.stl"/>
@@ -49,12 +49,6 @@
 				</material>
 
 			</visual>
-      <collision>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <geometry>
-          <box size="0 0 0"/>
-        </geometry>
-      </collision>
 	</link>
 
 
@@ -66,7 +60,7 @@
                iyy="1" iyz="0"
                izz="1"/>
   	 	</inertial>
-      <visual name="base_visual">
+      <visual>
         <origin xyz="0 0 0" rpy="0 0 0"/>
 				<geometry name="pioneer_geom">
 					<mesh filename="package://p2os_urdf/meshes/top_plate.stl"/>
@@ -75,12 +69,6 @@
 					<color rgba="0 0 0 1"/>
 				</material>
 			</visual>
-      <collision>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <geometry>
-          <box size="0 0 0"/>
-        </geometry>
-      </collision>
 	</link>
 
 	<link name="caster_plate">
@@ -91,7 +79,7 @@
                iyy="1" iyz="0"
                izz="1"/>
   	 	</inertial>
-      <visual name="base_visual">
+      <visual>
         <origin xyz="0 0 0" rpy="0 0 0"/>
 				<geometry name="pioneer_geom">
 					<mesh filename="package://p2os_urdf/meshes/caster_plate.stl"/>
@@ -100,12 +88,6 @@
 					<color rgba="0.5 0.5 0.5 1"/>
 				</material>
 			</visual>
-      <collision>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <geometry>
-          <box size="0 0 0"/>
-        </geometry>
-      </collision>
 	</link>
 	<link name="caster_mount">
 			<inertial>
@@ -115,7 +97,7 @@
                iyy="1" iyz="0"
                izz="1"/>
   	 	</inertial>
-      <visual name="base_visual">
+      <visual>
         <origin xyz="0 0 0" rpy="0 0 0"/>
 				<geometry name="pioneer_geom">
 					<mesh filename="package://p2os_urdf/meshes/caster_mount.stl"/>
@@ -124,12 +106,6 @@
 					<color rgba="0.5 0.5 0.5 1"/>
 				</material>
 			</visual>
-      <collision>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <geometry>
-          <box size="0 0 0"/>
-        </geometry>
-      </collision>
 	</link>
 
 	<link name="sonar">
@@ -140,7 +116,7 @@
                iyy="1" iyz="0"
                izz="1"/>
   	 	</inertial>
-      <visual name="base_visual">
+      <visual>
         <origin xyz="0 0 0" rpy="0 0 0"/>
 				<geometry name="pioneer_geom">
 					<mesh filename="package://p2os_urdf/meshes/sonars.stl"/>
@@ -149,12 +125,6 @@
 					<color rgba=".71875 0.48828125 0 1"/>
 				</material>
 			</visual>
-      <collision>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <geometry>
-          <box size="0 0 0"/>
-        </geometry>
-      </collision>
 	</link>
 	<link name="wheels_link">
 			<inertial>
@@ -164,7 +134,7 @@
                iyy="1" iyz="0"
                izz="1"/>
   	 	</inertial>
-      <visual name="base_visual">
+      <visual>
         <origin xyz="0 0 0" rpy="0 0 0"/>
 				<geometry name="pioneer_geom">
 					<mesh filename="package://p2os_urdf/meshes/wheels-center.stl"/>
@@ -173,12 +143,6 @@
 					<color rgba=".71875 0.48828125 0 1"/>
 				</material>
 			</visual>
-      <collision>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <geometry>
-          <box size="0 0 0"/>
-        </geometry>
-      </collision>
 	</link>
 	<link name="tires">
 			<inertial>
@@ -188,7 +152,7 @@
                iyy="1" iyz="0"
                izz="1"/>
   	 	</inertial>
-      <visual name="base_visual">
+      <visual>
         <origin xyz="0 0 0" rpy="0 0 0"/>
 				<geometry name="pioneer_geom">
 					<mesh filename="package://p2os_urdf/meshes/tires.stl"/>
@@ -197,12 +161,6 @@
 					<color rgba="0 0 0 1"/>
 				</material>
 			</visual>
-      <collision>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <geometry>
-          <box size="0 0 0"/>
-        </geometry>
-      </collision>
 	</link>
 	<joint name="base_top_joint" type="fixed">
     <origin xyz="0 0 0" rpy="0 0 0"/>

--- a/description/urdf/pioneer3dx_wheel.xacro
+++ b/description/urdf/pioneer3dx_wheel.xacro
@@ -21,7 +21,7 @@
       <inertia ixx="0.012411765597" ixy="0" ixz="0"
          iyy="0.015218160428" iyz="0" izz="0.011763977943"/>
       </inertial>
-    <visual name="base_visual">
+    <visual>
       <origin xyz="0 0 0" rpy="0 0 0"/>
       <geometry name="pioneer_geom">
         <mesh filename="package://amr_robots_description/meshes/p3dx_meshes/${suffix}_wheel.stl"/>
@@ -54,7 +54,7 @@
       <inertia ixx="0.012411765597" ixy="0" ixz="0"
          iyy="0.015218160428" iyz="0" izz="0.011763977943"/>
       </inertial>
-  <visual name="base_visual">
+  <visual>
     <origin xyz="0 0 0" rpy="0 0 0"/>
     <geometry name="pioneer_geom">
       <mesh filename="package://amr_robots_description/meshes/p3dx_meshes/${suffix}_hubcap.stl"/>

--- a/description/urdf/powerbot.urdf
+++ b/description/urdf/powerbot.urdf
@@ -27,7 +27,7 @@ right dimensions.
       <origin xyz="0.45 0.34 0.24"/>
       <inertia ixx="5.652232699207" ixy="-0.009719934438" ixz="1.293988226423" iyy="5.669473158652" iyz="-0.007379583694" izz="3.683196351726"/>
     </inertial>
-    <visual name="base_visual">
+    <visual>
       <origin rpy="0 0 0" xyz="-0.1 0 0.24"/>
       <geometry name="base_visual_geom">
         <box size="0.9 0.68 0.48"/>

--- a/description/urdf/powerbot.urdf.xacro
+++ b/description/urdf/powerbot.urdf.xacro
@@ -53,7 +53,7 @@ right dimensions.
 		iyy="5.669473158652" iyz="-0.007379583694" izz="3.683196351726" />
     </inertial>
 
-    <visual name="base_visual">
+    <visual>
       <origin xyz="-${base_center_offset} 0 ${base_size_z/2}" rpy="0 0 0" />
       <geometry name="base_visual_geom">
 	<box size="${base_size_x} ${base_size_y} ${base_size_z}" />

--- a/description/urdf/seekurjr.urdf
+++ b/description/urdf/seekurjr.urdf
@@ -11,7 +11,7 @@
       <origin xyz="0 0 0.177"/>
       <inertia ixx="0.3338" ixy="0.0" ixz="0.0" iyy="0.4783" iyz="0.0" izz="0.3338"/>
     </inertial>
-    <visual name="skj_base_visual">
+    <visual>
       <origin rpy="0 0 0" xyz="0 0 0.177"/>
       <geometry name="skj_geom">
         <!-- mesh filename="package://amr_robots_description/meshes/seekurjr_meshes/body.stl"/ -->
@@ -38,7 +38,7 @@
       <origin xyz="0 0 0"/>
       <inertia ixx="0.012411765597" ixy="0" ixz="0" iyy="0.015218160428" iyz="0" izz="0.011763977943"/>
     </inertial>
-    <visual name="base_visual">
+    <visual>
       <origin rpy="-1.570795 0 0" xyz="0 0 0"/>
       <geometry name="skj_wheel_geom">
         <!-- mesh filename="package://amr_robots_description/meshes/skj_meshes/wheel.stl"/ -->
@@ -87,7 +87,7 @@
       <origin xyz="0 0 0"/>
       <inertia ixx="0.012411765597" ixy="0" ixz="0" iyy="0.015218160428" iyz="0" izz="0.011763977943"/>
     </inertial>
-    <visual name="base_visual">
+    <visual>
       <origin rpy="-1.570795 0 0" xyz="0 0 0"/>
       <geometry name="skj_wheel_geom">
         <!-- mesh filename="package://amr_robots_description/meshes/skj_meshes/wheel.stl"/ -->
@@ -136,7 +136,7 @@
       <origin xyz="0 0 0"/>
       <inertia ixx="0.012411765597" ixy="0" ixz="0" iyy="0.015218160428" iyz="0" izz="0.011763977943"/>
     </inertial>
-    <visual name="base_visual">
+    <visual>
       <origin rpy="-1.570795 0 0" xyz="0 0 0"/>
       <geometry name="skj_wheel_geom">
         <!-- mesh filename="package://amr_robots_description/meshes/skj_meshes/wheel.stl"/ -->
@@ -185,7 +185,7 @@
       <origin xyz="0 0 0"/>
       <inertia ixx="0.012411765597" ixy="0" ixz="0" iyy="0.015218160428" iyz="0" izz="0.011763977943"/>
     </inertial>
-    <visual name="base_visual">
+    <visual>
       <origin rpy="-1.570795 0 0" xyz="0 0 0"/>
       <geometry name="skj_wheel_geom">
         <!-- mesh filename="package://amr_robots_description/meshes/skj_meshes/wheel.stl"/ -->

--- a/description/urdf/seekurjr.urdf.xacro
+++ b/description/urdf/seekurjr.urdf.xacro
@@ -15,7 +15,7 @@ name="skj">
 				 iyy="0.4783" iyz="0.0"
 				 izz="0.3338"/>
 		</inertial>
-		<visual name="skj_base_visual">
+		<visual>
 			<origin xyz="0 0 0.177" rpy="0 0 0"/>
 			<geometry name="skj_geom">
 				<!-- mesh filename="package://amr_robots_description/meshes/seekurjr_meshes/body.stl"/ -->
@@ -47,7 +47,7 @@ name="skj">
         <inertia ixx="0.012411765597" ixy="0" ixz="0"
            iyy="0.015218160428" iyz="0" izz="0.011763977943"/>
       </inertial>
-      <visual name="base_visual">
+      <visual>
         <origin xyz="0 0 0" rpy="-1.570795 0 0"/>
         <geometry name="skj_wheel_geom">
           <!-- mesh filename="package://amr_robots_description/meshes/skj_meshes/wheel.stl"/ -->


### PR DESCRIPTION
Collision boxes were with size="0 0 0", which caused errors in gazebo 7 (ogre 1.9), so I've removed them.

**Note** : in Thomas's fork he just set 0.001 size for there boxes. So it's up to you to decide which approach is better.